### PR TITLE
Add info about the 1.9 colour channel IDs and 1.9 colour channel property

### DIFF
--- a/docs/resources/client/level-components/level-colors.md
+++ b/docs/resources/client/level-components/level-colors.md
@@ -78,7 +78,7 @@ Here are all of the different color id's:
 `LIGHTER`: A lighter version of the primary color in objects. Used in the white small blocks found in `build tab 2 on page 6`.
 
 ### 1.9 color channel ID's
-GD's 1.9 version used a different ID scheme to identify color channels. In 2.1, these IDs are still present, but only used in the `1.9 Color Channel ID` property of 1.9 objects. They are as follows:
+GD's 1.9 version used a different ID scheme to identify color channels. In 2.1, these IDs are still present, but only used in the legacy `1.9 Color Channel ID` property of 1.9 objects. They are as follows:
 | 1.9 Channel ID | Name | Corresponding 2.1 ID |
 |:----|:---------|:-----------------------------|
 | `1` | **P1**    | `1005`

--- a/docs/resources/client/level-components/level-colors.md
+++ b/docs/resources/client/level-components/level-colors.md
@@ -78,8 +78,8 @@ Here are all of the different color id's:
 `LIGHTER`: A lighter version of the primary color in objects. Used in the white small blocks found in `build tab 2 on page 6`.
 
 ### 1.9 color channel ID's
-GD's 1.9 version used a different ID scheme to identify color channels. In 2.1, these IDs are still present, but only used in the legacy `1.9 Color Channel ID` property of 1.9 objects. They are as follows:
-| 1.9 Channel ID | Name | Corresponding 2.1 ID |
+GD's 1.9 version used a different ID scheme to identify color channels. In 2.0+, these IDs are still present, but only used in the legacy `1.9 Color Channel ID` property of 1.9 objects. They are as follows:
+| 1.9 Channel ID | Name | Corresponding 2.0+ ID |
 |:----|:---------|:-----------------------------|
 | `1` | **P1**    | `1005`
 | `2` | **P2**    | `1006`

--- a/docs/resources/client/level-components/level-colors.md
+++ b/docs/resources/client/level-components/level-colors.md
@@ -73,9 +73,22 @@ Here are all of the different color id's:
 | `1009`    | **G2**            | This is the secondary color of the ground |
 | `1010`    | **BLACK**         | This is the static color channel which is always `r: 0, g: 0, b: 0`. Used in saws that are black by default |
 
-### Undiscovered color channel id's
+### Undiscovered color channel IDs
 `WHITE`: Static color that is always `r: 255, g: 255, b: 255`  
 `LIGHTER`: A lighter version of the primary color in objects. Used in the white small blocks found in `build tab 2 on page 6`.
+
+### 1.9 color channel ID's
+GD's 1.9 version used a different ID scheme to identify color channels. In 2.1, these IDs are still present, but only used in the `1.9 Color Channel ID` property of 1.9 objects. They are as follows:
+| 1.9 Channel ID | Name | Corresponding 2.1 ID |
+|:----|:---------|:-----------------------------|
+| `1` | **P1**    | `1005`
+| `2` | **P2**    | `1006`
+| `3` | **COL 1** | `1`
+| `4` | **COL 2** | `2`
+| `5` | **LBG**   | `1007`
+| `6` | **COL 3** | `3`
+| `7` | **COL 4** | `4`
+| `8` | **3DL**   | `1003`
 
 ### Light Background (LBG) calculation
 The LBG takes the HSV of background. Subtracts `20` from its saturation, then interpolates from `P1` to the last HSV by a factor of the last HSV's value devided by `100`.

--- a/docs/resources/client/level-components/level-object.md
+++ b/docs/resources/client/level-components/level-object.md
@@ -63,6 +63,7 @@ Property keys reflect the keys found in the following table, whereas property va
 | 15  | Player Color 1                       | **bool**                                        | the Player Color 1 property of any Color trigger                                   |
 | 16  | Player Color 2                       | **bool**                                        | the Player Color 2 property of any Color trigger                                   |
 | 17  | Blending                             | **bool**                                        | the Blending property of any Color trigger                                         |
+| 19  | 1.9 Color Channel ID                 | **integer**                                     | the legacy Color Channel ID property used in 1.9 levels. If set to a valid value, both the Main and Secondary Color Channel ID properties will be ignored. |
 | 20  | Editor Layer 1                       | **integer**                                     | the Editor Layer 1 property of the object                                          |
 | 21  | Main Color Channel ID                | **integer**                                     | the Main Color Channel ID property of the object                                   |
 | 22  | Secondary Color Channel ID           | **integer**                                     | the Secondary Color Channel ID property of the object                              |
@@ -162,7 +163,6 @@ The following key ranges are potentially discarded features, whose appearance in
   </tr>
   <tr>
     <td align="center">18</td>
-    <td align="center">19</td>
   </tr>
   <tr>
     <td align="center">26</td>

--- a/docs/resources/client/level-components/level-object.md
+++ b/docs/resources/client/level-components/level-object.md
@@ -162,7 +162,7 @@ The following key ranges are potentially discarded features, whose appearance in
     <th>Key End</th>
   </tr>
   <tr>
-    <td align="center">18</td>
+    <td align="center" colspan="2">18</td>
   </tr>
   <tr>
     <td align="center">26</td>


### PR DESCRIPTION
been doing some stuff with a 1.9 apk in Ghidra and i've found out that
- 1.9 objects use property 19 to set their colour (using a colour id system that is different to 2.0+)
- if you set this property to a valid value, both the main and secondary colour channel id properties will be ignored (not just the secondary)
![image](https://user-images.githubusercontent.com/52147022/184304164-e690c5ba-c334-4e57-a044-3acab4a04739.png)
no idea if this is worth being on here (and everything i wrote probably needs to be reworded) but it's an interesting find
